### PR TITLE
FEAT: Order, Stock의 트랜잭션 처리 구현

### DIFF
--- a/order-service/src/main/java/com/teamsparta8/order_service/OrderServiceApplication.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/OrderServiceApplication.java
@@ -4,9 +4,11 @@ package com.teamsparta8.order_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableJpaAuditing
 public class OrderServiceApplication {
 
 	public static void main(String[] args) {

--- a/order-service/src/main/java/com/teamsparta8/order_service/OrderServiceApplication.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/OrderServiceApplication.java
@@ -1,0 +1,16 @@
+package com.teamsparta8.order_service;
+
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+@SpringBootApplication
+@EnableFeignClients
+public class OrderServiceApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(OrderServiceApplication.class, args);
+	}
+
+}

--- a/order-service/src/main/java/com/teamsparta8/order_service/application/dto/OrderMapper.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/application/dto/OrderMapper.java
@@ -31,6 +31,7 @@ public class OrderMapper {
 				.hubId(order.getHubId())
 				.deliveryId(order.getDeliveryId())
 				.quantity(order.getQuantity())
+				.totalPrice(order.getTotalPrice())
 				.requestDescription(order.getRequestDescription())
 				.build())
 			.companyInfo(CreateOrderResponse.CompanyInfo.builder()

--- a/order-service/src/main/java/com/teamsparta8/order_service/application/service/OrderService.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/application/service/OrderService.java
@@ -9,17 +9,23 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.querydsl.core.QueryResults;
+import com.teamsparta8.order_service.infrastructure.client.DeliveryClient;
+import com.teamsparta8.order_service.infrastructure.client.StockClient;
 import com.teamsparta8.order_service.infrastructure.repository.OrderQueryRepository;
 import com.teamsparta8.order_service.infrastructure.util.PaginationUtil;
 import com.teamsparta8.order_service.presentatin.dto.CommonResponse;
+import com.teamsparta8.order_service.presentatin.dto.CreateDeliveryRequest;
+import com.teamsparta8.order_service.presentatin.dto.CreateDeliveryResponse;
 import com.teamsparta8.order_service.presentatin.dto.CreateOrderRequest;
 import com.teamsparta8.order_service.presentatin.dto.CreateOrderResponse;
 import com.teamsparta8.order_service.application.dto.OrderMapper;
 import com.teamsparta8.order_service.domain.model.Order;
 import com.teamsparta8.order_service.domain.repository.OrderRepository;
 import com.teamsparta8.order_service.domain.service.OrderDomainService;
+import com.teamsparta8.order_service.presentatin.dto.DecreaseStockRequest;
 import com.teamsparta8.order_service.presentatin.dto.OrderPageResponse;
 import com.teamsparta8.order_service.presentatin.dto.Pagination;
+import com.teamsparta8.order_service.presentatin.dto.StockCheckResponse;
 import com.teamsparta8.order_service.presentatin.dto.UpdateOrderRequest;
 
 import lombok.RequiredArgsConstructor;
@@ -27,78 +33,80 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class OrderService {
-	private final OrderRepository orderRepository;
 	private final OrderDomainService orderDomainService;
 	private final OrderMapper orderMapper;
 	private final OrderQueryRepository orderQueryRepository;
+	private final StockClient stockClient;
+	private final DeliveryClient deliveryClient;
 	@Transactional
 	public CreateOrderResponse createOrder(CreateOrderRequest request) {
-		UUID hubId = UUID.randomUUID();
-		UUID deliveryId = UUID.randomUUID();
-		// 도메인 서비스 호출 (비즈니스 로직 위임)
+		// 1. Stock Service를 통한 재고 확인 및 차감
+		DecreaseStockRequest stockRequest = new DecreaseStockRequest(request.getProductId(), request.getQuantity());
+		StockCheckResponse stockResponse;
+		try {
+			stockResponse = stockClient.checkAndDecreaseStock(stockRequest);
+		} catch (Exception e) {
+			throw new RuntimeException("재고 확인 및 차감 실패: " + e.getMessage());
+		}
+
+		int totalPrice = stockResponse.getPrice() * request.getQuantity();
+
+		// 2. 도메인 서비스 호출하여 Order 생성
 		Order order = orderDomainService.createOrder(
 			request.getSupplierCompanyId(),
 			request.getReceiverCompanyId(),
 			request.getProductId(),
-			hubId,
-			deliveryId,
+			stockResponse.getHubId(),
+			null,
 			request.getQuantity(),
+			totalPrice,
 			request.getRequestDescription()
 		);
+		// 3. 주문 저장 (deliveryId 없이 우선 저장)
+		orderDomainService.saveOrder(order);
+
+		// 4. Delivery 서비스 호출
+		CreateDeliveryRequest deliveryRequest = new CreateDeliveryRequest(order.getOrderId());
+		CreateDeliveryResponse deliveryResponse = deliveryClient.createDelivery(deliveryRequest);
+
+		// 5. 받은 deliveryId로 주문 정보 업데이트
+		orderDomainService.updateDeliveryId(order, deliveryResponse.getDeliveryId());
+
+		// 6. 응답 변환 및 반환
+		return orderMapper.fromEntity(order);
+	}
 
 
-		orderRepository.save(order); //JPA에서 persist()가 실행되도록 보장
 
+
+	@Transactional
+	public CreateOrderResponse updateOrder(UUID orderId, UpdateOrderRequest request) {
+		Order order = orderDomainService.getOrderById(orderId);
+		Order updated = orderDomainService.updateOrder(order, request.getQuantity(), request.getRequestDescription());
+		orderDomainService.saveOrder(updated);
+		return orderMapper.fromEntity(updated);
+	}
+
+	//단건 조회
+
+	@Transactional(readOnly = true)
+	public CreateOrderResponse getOrderById(UUID orderId) {
+		Order order = orderDomainService.getOrderById(orderId);
 		return orderMapper.fromEntity(order);
 	}
 
 	@Transactional
-	public CreateOrderResponse updateOrder(UUID orderId, UpdateOrderRequest request) {
-		Order order = orderRepository.findById(orderId)
-			.orElseThrow(() -> new RuntimeException("주문을 찾을 수 없습니다."));
-
-		Order updatedOrder = orderDomainService.updateOrder(order, request.getQuantity(), request.getRequestDescription());
-
-		orderRepository.save(updatedOrder);
-
-		return orderMapper.fromEntity(updatedOrder);
+	public void deleteOrder(UUID orderId) {
+		orderDomainService.deleteOrder(orderId);
 	}
-	//단건 조회
-	public CreateOrderResponse getOrderById(UUID orderId) {
-		Order order = orderRepository.findById(orderId)
-			.orElseThrow(() -> new RuntimeException("주문을 찾을 수 없습니다."));
-		return orderMapper.fromEntity(order); //
-	}
-
 	//목록 조회
 	@Transactional(readOnly = true)
-	public OrderPageResponse getUserOrders(UUID userId, int page, int size) {
-		QueryResults<Order> queryResults = orderQueryRepository.findOrdersByUserId(userId, page, size);
+	public OrderPageResponse getAllOrders(int page, int size) {
+		QueryResults<Order> queryResults = orderDomainService.getAllOrders(page, size);
 		List<CreateOrderResponse> response = PaginationUtil.mapResults(queryResults, orderMapper::fromEntity);
 		Pagination pagination = PaginationUtil.createPagination(queryResults, page, size);
 		return new OrderPageResponse(response, pagination);
 	}
-
-	@Transactional(readOnly = true)
-	public OrderPageResponse getOrdersByHub(UUID hubId, int page, int size) {
-		QueryResults<Order> queryResults = orderQueryRepository.findOrdersByHubId(hubId, page, size);
-		List<CreateOrderResponse> response = PaginationUtil.mapResults(queryResults, orderMapper::fromEntity);
-		Pagination pagination = PaginationUtil.createPagination(queryResults, page, size);
-		return new OrderPageResponse(response, pagination);
-	}
-
-	@Transactional(readOnly = true)
-	public OrderPageResponse getOrdersByDeliveryId(UUID deliveryId, int page, int size) {
-		QueryResults<Order> queryResults = orderQueryRepository.findOrdersByDeliveryId(deliveryId, page, size);
-		List<CreateOrderResponse> response = PaginationUtil.mapResults(queryResults, orderMapper::fromEntity);
-		Pagination pagination = PaginationUtil.createPagination(queryResults, page, size);
-		return new OrderPageResponse(response, pagination);
-	}
-
-	public void deleteOrder(UUID orderId) {
-		orderRepository.deleteById(orderId);
-	}
-
 	@Transactional(readOnly = true)
 	public OrderPageResponse searchOrders(UUID userId, UUID hubId, UUID deliveryId, String status, int page, int size) {
 		QueryResults<Order> queryResults = orderQueryRepository.searchOrders(userId, hubId, deliveryId, status, page, size);

--- a/order-service/src/main/java/com/teamsparta8/order_service/application/service/OrderService.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/application/service/OrderService.java
@@ -158,6 +158,18 @@ public class OrderService {
 
 	@Transactional
 	public void deleteOrder(UUID orderId) {
+		// 1. 기존 주문 조회
+		Order existingOrder = orderDomainService.getOrderById(orderId);
+
+		try {
+			// 2. 주문 수량만큼 재고 복원
+			rollbackStock(existingOrder.getProductId(), existingOrder.getQuantity());
+		} catch (Exception e) {
+			log.error("주문 삭제 중 재고 복구 실패", e);
+			throw new RuntimeException("재고 복구 실패로 주문 삭제 불가: " + e.getMessage());
+		}
+
+		// 3. 실제 주문 삭제
 		orderDomainService.deleteOrder(orderId);
 	}
 	//목록 조회

--- a/order-service/src/main/java/com/teamsparta8/order_service/application/service/OrderService.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/application/service/OrderService.java
@@ -25,12 +25,15 @@ import com.teamsparta8.order_service.domain.service.OrderDomainService;
 import com.teamsparta8.order_service.presentatin.dto.DecreaseStockRequest;
 import com.teamsparta8.order_service.presentatin.dto.OrderPageResponse;
 import com.teamsparta8.order_service.presentatin.dto.Pagination;
+import com.teamsparta8.order_service.presentatin.dto.RollbackStockRequest;
 import com.teamsparta8.order_service.presentatin.dto.StockCheckResponse;
 import com.teamsparta8.order_service.presentatin.dto.UpdateOrderRequest;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class OrderService {
 	private final OrderDomainService orderDomainService;
@@ -40,55 +43,101 @@ public class OrderService {
 	private final DeliveryClient deliveryClient;
 	@Transactional
 	public CreateOrderResponse createOrder(CreateOrderRequest request) {
-		// 1. Stock Service를 통한 재고 확인 및 차감
-		DecreaseStockRequest stockRequest = new DecreaseStockRequest(request.getProductId(), request.getQuantity());
-		StockCheckResponse stockResponse;
+		StockCheckResponse stockResponse = null;
 		try {
-			stockResponse = stockClient.checkAndDecreaseStock(stockRequest);
+			// 1. Stock Service를 통한 재고 확인 및 차감
+			DecreaseStockRequest stockRequest = new DecreaseStockRequest(request.getProductId(), request.getQuantity());
+			// StockCheckResponse stockResponse;
+			try {
+				CommonResponse<StockCheckResponse> response = stockClient.checkAndDecreaseStock(stockRequest);
+				stockResponse = response.getData();
+			} catch (Exception e) {
+				throw new RuntimeException("재고 확인 및 차감 실패: " + e.getMessage());
+			}
+
+			int totalPrice = stockResponse.getPrice() * request.getQuantity();
+
+			// 2. 도메인 서비스 호출하여 Order 생성
+			Order order = orderDomainService.createOrder(
+				request.getSupplierCompanyId(),
+				request.getReceiverCompanyId(),
+				request.getProductId(),
+				stockResponse.getHubId(),
+				null,
+				request.getQuantity(),
+				totalPrice,
+				request.getRequestDescription()
+			);
+
+			//3. 주문 저장 (deliveryId 없이 우선 저장)
+			orderDomainService.saveOrder(order);
+
+			// // 4. Delivery 서비스 호출(테스트 중이라 주석처리)
+			// CreateDeliveryRequest deliveryRequest = new CreateDeliveryRequest(order.getOrderId());
+			// CreateDeliveryResponse deliveryResponse = deliveryClient.createDelivery(deliveryRequest);
+
+			// // 5. 받은 deliveryId로 주문 정보 업데이트
+			// orderDomainService.updateDeliveryId(order, deliveryResponse.getDeliveryId());
+
+			UUID dummyDeliveryId = UUID.randomUUID();
+			orderDomainService.updateDeliveryId(order, dummyDeliveryId);
+
+			// 6. 응답 변환 및 반환
+			return orderMapper.fromEntity(order);
+
 		} catch (Exception e) {
-			throw new RuntimeException("재고 확인 및 차감 실패: " + e.getMessage());
+			log.warn("주문 생성 도중 예외 발생 → 보상 트랜잭션 조건 확인 중: {}", e.getMessage());
+			// 7. 예외 발생 시 → 보상 트랜잭션 수행, rollback은 재고 차감까지 된 경우에만!!
+			// rollbackStock(request.getProductId(), request.getQuantity());
+			if (stockResponse != null) {
+				log.warn("배송 생성 실패로 보상 트랜잭션 수행 시작 (rollbackStock 호출)");
+
+				try {
+					rollbackStock(request.getProductId(), request.getQuantity());
+					log.info("보상 트랜잭션 성공: 재고 복구 완료");
+				} catch (Exception rollbackEx) {
+					log.error("보상 트랜잭션 실패: 재고 복구 실패", rollbackEx);
+				}
+			}
+			throw new RuntimeException("주문 생성 실패 -> 보상 트랜잭션 수행!: " + e.getMessage());
 		}
-
-		int totalPrice = stockResponse.getPrice() * request.getQuantity();
-
-		// 2. 도메인 서비스 호출하여 Order 생성
-		Order order = orderDomainService.createOrder(
-			request.getSupplierCompanyId(),
-			request.getReceiverCompanyId(),
-			request.getProductId(),
-			stockResponse.getHubId(),
-			null,
-			request.getQuantity(),
-			totalPrice,
-			request.getRequestDescription()
-		);
-		// 3. 주문 저장 (deliveryId 없이 우선 저장)
-		orderDomainService.saveOrder(order);
-
-		// 4. Delivery 서비스 호출
-		CreateDeliveryRequest deliveryRequest = new CreateDeliveryRequest(order.getOrderId());
-		CreateDeliveryResponse deliveryResponse = deliveryClient.createDelivery(deliveryRequest);
-
-		// 5. 받은 deliveryId로 주문 정보 업데이트
-		orderDomainService.updateDeliveryId(order, deliveryResponse.getDeliveryId());
-
-		// 6. 응답 변환 및 반환
-		return orderMapper.fromEntity(order);
 	}
 
-
-
+	private void rollbackStock(UUID productId, int quantity) {
+		try {
+			stockClient.rollbackStock(new RollbackStockRequest(productId, quantity));
+		} catch (Exception ex) {
+			log.error("보상 트랜잭션 실패: 재고 복구 실패", ex);
+		}
+	}
 
 	@Transactional
 	public CreateOrderResponse updateOrder(UUID orderId, UpdateOrderRequest request) {
+		// 1. 주문 조회
 		Order order = orderDomainService.getOrderById(orderId);
-		Order updated = orderDomainService.updateOrder(order, request.getQuantity(), request.getRequestDescription());
+
+		// 2. 가격 정보 가져오기 (StockService에서 productId로 조회)
+		CommonResponse<StockCheckResponse> stockResponse = stockClient.checkAndDecreaseStock(
+			new DecreaseStockRequest(order.getProductId(), 0) // 차감은 하지 않고 price/hubId만 확인용
+		);
+		int price = stockResponse.getData().getPrice();
+		int newTotalPrice = price * request.getQuantity();
+
+		// 3. 도메인 서비스에 넘겨서 업데이트
+		Order updated = orderDomainService.updateOrder(
+			order,
+			request.getQuantity(),
+			newTotalPrice,
+			request.getRequestDescription()
+		);
+
 		orderDomainService.saveOrder(updated);
+
+		// 4. 응답 반환
 		return orderMapper.fromEntity(updated);
 	}
 
 	//단건 조회
-
 	@Transactional(readOnly = true)
 	public CreateOrderResponse getOrderById(UUID orderId) {
 		Order order = orderDomainService.getOrderById(orderId);

--- a/order-service/src/main/java/com/teamsparta8/order_service/domain/model/Order.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/domain/model/Order.java
@@ -26,8 +26,6 @@ public class Order extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	private UUID orderId;
 	@Column(nullable = false)
-	private UUID userId; // 주문을 생성한 사용자 ID 추가
-	@Column(nullable = false)
 	private UUID supplierCompanyId; //업체 담당자 조회 필터링 가능
 
 	@Column(nullable = false)
@@ -45,15 +43,12 @@ public class Order extends BaseEntity {
 	@Column(nullable = false)
 	private int quantity;
 
+	@Column(nullable = false)
+	private int totalPrice;
 	@Column(length = 255)
 	private String requestDescription;
-
-	public void updateHubId(UUID hubId) {
-		this.hubId = hubId;
-	}
 
 	public void updateDeliveryId(UUID deliveryId) {
 		this.deliveryId = deliveryId;
 	}
-
 }

--- a/order-service/src/main/java/com/teamsparta8/order_service/domain/service/OrderDomainService.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/domain/service/OrderDomainService.java
@@ -3,8 +3,12 @@ package com.teamsparta8.order_service.domain.service;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.querydsl.core.QueryResults;
 import com.teamsparta8.order_service.domain.model.Order;
+import com.teamsparta8.order_service.domain.repository.OrderRepository;
+import com.teamsparta8.order_service.infrastructure.repository.OrderQueryRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,30 +16,29 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OrderDomainService {
 
+	private final OrderRepository orderRepository;
+	private final OrderQueryRepository orderQueryRepository;
+
 	// 주문 생성 시 비즈니스 규칙 적용
-	public Order createOrder(
-		UUID supplierCompanyId,
-		UUID receiverCompanyId,
-		UUID productId,
-		UUID hubId,
-		UUID deliveryId,
-		int quantity,
-		String requestDescription
+	public Order createOrder(UUID supplierCompanyId, UUID receiverCompanyId, UUID productId, UUID hubId, UUID deliveryId, int quantity, int totalPrice, String requestDescription
 	) {
-		// 주문 생성 규칙 예시 (비즈니스 로직)
+
 		if (quantity <= 0) {
 			throw new IllegalArgumentException("수량은 0보다 커야 합니다.");
 		}
 
-		return Order.builder()
+		Order order = Order.builder()
 			.supplierCompanyId(supplierCompanyId)
 			.receiverCompanyId(receiverCompanyId)
 			.productId(productId)
 			.hubId(hubId)
 			.deliveryId(deliveryId)
 			.quantity(quantity)
+			.totalPrice(totalPrice)
 			.requestDescription(requestDescription)
 			.build();
+
+		return orderRepository.save(order);
 	}
 
 	public Order updateOrder(Order order, int quantity, String requestDescription) {
@@ -53,7 +56,29 @@ public class OrderDomainService {
 			.hubId(order.getHubId())
 			.deliveryId(order.getDeliveryId())
 			.quantity(quantity)
+			.totalPrice(order.getTotalPrice())
 			.requestDescription(requestDescription)
 			.build();
+	}
+
+	@Transactional(readOnly = true)
+	public QueryResults<Order> getAllOrders(int page, int size) {
+		return orderQueryRepository.findAllOrders(page, size);
+	}
+	public Order getOrderById(UUID orderId) {
+		return orderRepository.findById(orderId)
+			.orElseThrow(() -> new RuntimeException("주문을 찾을 수 없습니다."));
+	}
+
+	public void deleteOrder(UUID orderId) {
+		orderRepository.deleteById(orderId);
+	}
+	public Order saveOrder(Order order) {
+		return orderRepository.save(order);
+	}
+
+	public void updateDeliveryId(Order order, UUID deliveryId) {
+		order.updateDeliveryId(deliveryId);
+		orderRepository.save(order); // JPA dirty checking 보장용
 	}
 }

--- a/order-service/src/main/java/com/teamsparta8/order_service/domain/service/OrderDomainService.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/domain/service/OrderDomainService.java
@@ -27,7 +27,7 @@ public class OrderDomainService {
 			throw new IllegalArgumentException("수량은 0보다 커야 합니다.");
 		}
 
-		Order order = Order.builder()
+		return Order.builder()
 			.supplierCompanyId(supplierCompanyId)
 			.receiverCompanyId(receiverCompanyId)
 			.productId(productId)
@@ -38,10 +38,9 @@ public class OrderDomainService {
 			.requestDescription(requestDescription)
 			.build();
 
-		return orderRepository.save(order);
 	}
 
-	public Order updateOrder(Order order, int quantity, String requestDescription) {
+	public Order updateOrder(Order order, int quantity,int totalPrice, String requestDescription) {
 		//  수량 검증
 		if (quantity <= 0) {
 			throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
@@ -56,7 +55,7 @@ public class OrderDomainService {
 			.hubId(order.getHubId())
 			.deliveryId(order.getDeliveryId())
 			.quantity(quantity)
-			.totalPrice(order.getTotalPrice())
+			.totalPrice(totalPrice)
 			.requestDescription(requestDescription)
 			.build();
 	}

--- a/order-service/src/main/java/com/teamsparta8/order_service/domain/service/OrderDomainService.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/domain/service/OrderDomainService.java
@@ -40,7 +40,7 @@ public class OrderDomainService {
 
 	}
 
-	public Order updateOrder(Order order, int quantity,int totalPrice, String requestDescription) {
+	public Order updateOrder(Order order, int quantity, String requestDescription, int totalPrice) {
 		//  수량 검증
 		if (quantity <= 0) {
 			throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
@@ -55,8 +55,8 @@ public class OrderDomainService {
 			.hubId(order.getHubId())
 			.deliveryId(order.getDeliveryId())
 			.quantity(quantity)
-			.totalPrice(totalPrice)
 			.requestDescription(requestDescription)
+			.totalPrice(totalPrice)
 			.build();
 	}
 

--- a/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/DeliveryClient.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/DeliveryClient.java
@@ -1,0 +1,15 @@
+package com.teamsparta8.order_service.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.teamsparta8.order_service.presentatin.dto.CreateDeliveryRequest;
+import com.teamsparta8.order_service.presentatin.dto.CreateDeliveryResponse;
+
+@FeignClient(name = "delivery-service", url = "http://delivery-service")
+public interface DeliveryClient {
+	@PostMapping("/api/deliveries")
+	CreateDeliveryResponse createDelivery(@RequestBody CreateDeliveryRequest request);
+
+}

--- a/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/MockStockClient.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/MockStockClient.java
@@ -1,23 +1,23 @@
-package com.teamsparta8.order_service.infrastructure.client;
-
-import java.util.UUID;
-
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
-
-import com.teamsparta8.order_service.presentatin.dto.DecreaseStockRequest;
-import com.teamsparta8.order_service.presentatin.dto.StockCheckResponse;
-
-@Component
-@Profile("test")
-public class MockStockClient implements StockClient{
-
-	@Override
-	public StockCheckResponse checkAndDecreaseStock(DecreaseStockRequest request) {
-		return StockCheckResponse.builder()
-			.productId(request.getProductId())
-			.hubId(UUID.fromString("11111111-1111-1111-1111-111111111111")) // 고정된 허브 ID
-			.price(10000)
-			.build();
-	}
-}
+// package com.teamsparta8.order_service.infrastructure.client;
+//
+// import java.util.UUID;
+//
+// import org.springframework.context.annotation.Profile;
+// import org.springframework.stereotype.Component;
+//
+// import com.teamsparta8.order_service.presentatin.dto.DecreaseStockRequest;
+// import com.teamsparta8.order_service.presentatin.dto.StockCheckResponse;
+//
+// @Component
+// @Profile("test")
+// public class MockStockClient implements StockClient{
+//
+// 	@Override
+// 	public StockCheckResponse checkAndDecreaseStock(DecreaseStockRequest request) {
+// 		return StockCheckResponse.builder()
+// 			.productId(request.getProductId())
+// 			.hubId(UUID.fromString("11111111-1111-1111-1111-111111111111")) // 고정된 허브 ID
+// 			.price(10000)
+// 			.build();
+// 	}
+// }

--- a/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/MockStockClient.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/MockStockClient.java
@@ -1,0 +1,23 @@
+package com.teamsparta8.order_service.infrastructure.client;
+
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.teamsparta8.order_service.presentatin.dto.DecreaseStockRequest;
+import com.teamsparta8.order_service.presentatin.dto.StockCheckResponse;
+
+@Component
+@Profile("test")
+public class MockStockClient implements StockClient{
+
+	@Override
+	public StockCheckResponse checkAndDecreaseStock(DecreaseStockRequest request) {
+		return StockCheckResponse.builder()
+			.productId(request.getProductId())
+			.hubId(UUID.fromString("11111111-1111-1111-1111-111111111111")) // 고정된 허브 ID
+			.price(10000)
+			.build();
+	}
+}

--- a/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/ProductClient.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/ProductClient.java
@@ -1,7 +1,0 @@
-package com.teamsparta8.order_service.infrastructure.client;
-
-import org.springframework.cloud.openfeign.FeignClient;
-
-@FeignClient(name = "product-service", path = "/api/products")
-public class ProductClient {
-}

--- a/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/StockClient.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/StockClient.java
@@ -1,0 +1,29 @@
+package com.teamsparta8.order_service.infrastructure.client;
+
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.teamsparta8.order_service.presentatin.dto.DecreaseStockRequest;
+import com.teamsparta8.order_service.presentatin.dto.StockCheckResponse;
+@FeignClient(name = "stock-service", url = "http://localhost:8081", fallback = StockClient.DummyStockClient.class)
+public interface StockClient {
+	@PutMapping("/api/stocks/check")
+	StockCheckResponse checkAndDecreaseStock(@RequestBody DecreaseStockRequest request);
+
+
+	@Component
+	public class DummyStockClient implements StockClient {
+		@Override
+		public StockCheckResponse checkAndDecreaseStock(DecreaseStockRequest request) {
+			return StockCheckResponse.builder()
+				.productId(request.getProductId())
+				.hubId(UUID.randomUUID())
+				.price(9000)
+				.build();
+		}
+	}
+}

--- a/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/StockClient.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/client/StockClient.java
@@ -1,29 +1,30 @@
 package com.teamsparta8.order_service.infrastructure.client;
 
-import java.util.UUID;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import com.teamsparta8.order_service.presentatin.dto.CommonResponse;
 import com.teamsparta8.order_service.presentatin.dto.DecreaseStockRequest;
+import com.teamsparta8.order_service.presentatin.dto.RollbackStockRequest;
 import com.teamsparta8.order_service.presentatin.dto.StockCheckResponse;
-@FeignClient(name = "stock-service", url = "http://localhost:8081", fallback = StockClient.DummyStockClient.class)
+@FeignClient(name = "stock-service", url = "http://localhost:8082")
 public interface StockClient {
 	@PutMapping("/api/stocks/check")
-	StockCheckResponse checkAndDecreaseStock(@RequestBody DecreaseStockRequest request);
+	CommonResponse<StockCheckResponse>  checkAndDecreaseStock(@RequestBody DecreaseStockRequest request);
+	@PutMapping("/api/stocks/rollback")
+	void rollbackStock(@RequestBody RollbackStockRequest request);
 
-
-	@Component
-	public class DummyStockClient implements StockClient {
-		@Override
-		public StockCheckResponse checkAndDecreaseStock(DecreaseStockRequest request) {
-			return StockCheckResponse.builder()
-				.productId(request.getProductId())
-				.hubId(UUID.randomUUID())
-				.price(9000)
-				.build();
-		}
-	}
+	// @Component
+	// public class DummyStockClient implements StockClient {
+	// 	@Override
+	// 	public StockCheckResponse checkAndDecreaseStock(DecreaseStockRequest request) {
+	// 		return StockCheckResponse.builder()
+	// 			.productId(request.getProductId())
+	// 			.hubId(UUID.randomUUID())
+	// 			.price(9000)
+	// 			.build();
+	// 	}
+	// }
 }

--- a/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/repository/OrderQueryRepository.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/infrastructure/repository/OrderQueryRepository.java
@@ -16,36 +16,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OrderQueryRepository {
 	private final JPAQueryFactory queryFactory;
-
-	// [일반 사용자] 본인이 주문한 목록 조회
-	public QueryResults<Order> findOrdersByUserId(UUID userId, int page, int size) {
+	public QueryResults<Order> findAllOrders(int page, int size) {
 		QOrder order = QOrder.order;
 
 		return queryFactory.selectFrom(order)
-			.where(order.receiverCompanyId.eq(userId)) //주문 수취인 기준 필터링
-			.offset(page * size)
-			.limit(size)
-			.fetchResults();
-	}
-
-	// [허브 관리자] 허브 ID 기반 주문 조회
-	public QueryResults<Order> findOrdersByHubId(UUID hubId, int page, int size) {
-		QOrder order = QOrder.order;
-
-		return queryFactory.selectFrom(order)
-			.where(order.hubId.eq(hubId)) //허브 기준 필터링
-			.offset(page * size)
-			.limit(size)
-			.fetchResults();
-	}
-
-	// [배송 담당자] 본인이 담당하는 주문 목록 조회
-	public QueryResults<Order> findOrdersByDeliveryId(UUID deliveryId, int page, int size) {
-		QOrder order = QOrder.order;
-
-		return queryFactory.selectFrom(order)
-			.where(order.deliveryId.eq(deliveryId)) // 배송 담당자 기준 필터링
-			.offset(page * size)
+			.offset((long) page * size)
 			.limit(size)
 			.fetchResults();
 	}

--- a/order-service/src/main/java/com/teamsparta8/order_service/presentatin/controller/OrderController.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/presentatin/controller/OrderController.java
@@ -49,54 +49,6 @@ public class OrderController {
 		return ResponseEntity.ok(CommonResponse.OK(response, "주문이 성공적으로 수정되었습니다."));
 	}
 
-	// [일반 사용자] 본인이 주문한 목록 조회
-	@GetMapping("/my")
-	public ResponseEntity<CommonResponse<List<CreateOrderResponse>>> getMyOrders(
-		@RequestParam UUID userId,
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "10") int size
-	) {
-		OrderPageResponse orderPageResponse = orderService.getUserOrders(userId, page, size);
-		return ResponseEntity.ok(
-			CommonResponse.OK(orderPageResponse.getOrders(), "사용자 주문 목록 조회 성공", orderPageResponse.getPagination())
-		);
-	}
-
-	// [허브 관리자] 본인의 허브에서 관리하는 주문 목록 조회
-	@GetMapping("/hub")
-	public ResponseEntity<CommonResponse<List<CreateOrderResponse>>> getHubOrders(
-		@RequestParam String role,
-		@RequestParam UUID hubId,
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "10") int size
-	) {
-		if (!role.equals("HUB_MANAGER")) {
-			return ResponseEntity.badRequest().body(CommonResponse.ERROR("허브 관리자만 접근 가능합니다."));
-		}
-
-		OrderPageResponse orderPageResponse = orderService.getOrdersByHub(hubId, page, size);
-		return ResponseEntity.ok(
-			CommonResponse.OK(orderPageResponse.getOrders(), "허브 관리자 주문 목록 조회 성공", orderPageResponse.getPagination())
-		);
-	}
-
-	//[배송 담당자] 본인이 담당하는 주문 목록 조회
-	@GetMapping("/delivery")
-	public ResponseEntity<CommonResponse<List<CreateOrderResponse>>> getDeliveryOrders(
-		@RequestParam String role,
-		@RequestParam UUID userId,
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "10") int size
-	) {
-		if (!role.equals("DELIVERY_PERSON")) {
-			return ResponseEntity.badRequest().body(CommonResponse.ERROR("배송 담당자만 접근 가능합니다."));
-		}
-
-		OrderPageResponse orderPageResponse = orderService.getOrdersByDeliveryId(userId, page, size);
-		return ResponseEntity.ok(
-			CommonResponse.OK(orderPageResponse.getOrders(), "배송 담당자 주문 목록 조회 성공", orderPageResponse.getPagination())
-		);
-	}
 
 	// 주문 단일 조회
 	@GetMapping("/{orderId}")
@@ -125,4 +77,14 @@ public class OrderController {
 			CommonResponse.OK(orderPageResponse.getOrders(), "주문 검색 결과 조회 성공", orderPageResponse.getPagination())
 		);
 	}
+	//주문 조회
+	@GetMapping
+	public ResponseEntity<CommonResponse<OrderPageResponse>> getAllOrders(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		OrderPageResponse response = orderService.getAllOrders(page, size);
+		return ResponseEntity.ok(CommonResponse.OK(response, "주문 전체 목록 조회 성공"));
+	}
+
 }

--- a/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/CreateDeliveryRequest.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/CreateDeliveryRequest.java
@@ -1,0 +1,18 @@
+package com.teamsparta8.order_service.presentatin.dto;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateDeliveryRequest {
+	private UUID orderId;
+}

--- a/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/CreateDeliveryResponse.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/CreateDeliveryResponse.java
@@ -1,0 +1,18 @@
+package com.teamsparta8.order_service.presentatin.dto;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateDeliveryResponse {
+	private UUID deliveryId;
+}

--- a/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/CreateOrderResponse.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/CreateOrderResponse.java
@@ -17,6 +17,7 @@ public class CreateOrderResponse {
 	private OrderInfo orderInfo;
 	private CompanyInfo companyInfo;
 	private ProductInfo productInfo;
+
 	@Getter
 	@Setter
 	@Builder
@@ -27,6 +28,7 @@ public class CreateOrderResponse {
 		private UUID hubId;
 		private UUID deliveryId;
 		private int quantity;
+		private int totalPrice;
 		private String requestDescription;
 	}
 
@@ -48,5 +50,6 @@ public class CreateOrderResponse {
 	public static class ProductInfo {
 		private UUID productId;
 	}
-	private int totalPrice;
+
+
 }

--- a/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/CreateOrderResponse.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/CreateOrderResponse.java
@@ -48,4 +48,5 @@ public class CreateOrderResponse {
 	public static class ProductInfo {
 		private UUID productId;
 	}
+	private int totalPrice;
 }

--- a/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/DecreaseStockRequest.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/DecreaseStockRequest.java
@@ -1,0 +1,15 @@
+package com.teamsparta8.order_service.presentatin.dto;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DecreaseStockRequest {
+	private UUID productId;
+	private int quantity;
+}

--- a/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/RollbackStockRequest.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/RollbackStockRequest.java
@@ -1,0 +1,17 @@
+package com.teamsparta8.order_service.presentatin.dto;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RollbackStockRequest {
+	private UUID productId;
+	private int quantity;
+}

--- a/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/StockCheckResponse.java
+++ b/order-service/src/main/java/com/teamsparta8/order_service/presentatin/dto/StockCheckResponse.java
@@ -1,0 +1,18 @@
+package com.teamsparta8.order_service.presentatin.dto;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockCheckResponse {
+	private UUID productId;
+	private UUID hubId;
+	private int price;
+}

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -1,14 +1,14 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
-    username: postgres
+    url: jdbc:postgresql://localhost:5433/orderdb
+    username: orderdb
     password: 1234
     driver-class-name: org.postgresql.Driver
 
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
 #    data:
 #      redis:
 #        host: localhost

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/StockServiceApplication.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/StockServiceApplication.java
@@ -2,8 +2,12 @@ package com.teamsparta8.stock_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableJpaAuditing
 public class StockServiceApplication {
 
 	public static void main(String[] args) {

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/application/dto/StockMapper.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/application/dto/StockMapper.java
@@ -17,6 +17,7 @@ public class StockMapper {
 			.hubId(request.getHubId())
 			.productId(request.getProductId())
 			.quantity(request.getQuantity())
+			.price(request.getPrice())
 			.build();
 	}
 
@@ -26,6 +27,7 @@ public class StockMapper {
 			.hubId(stock.getHubId())
 			.productId(stock.getProductId())
 			.quantity(stock.getQuantity())
+			.price(stock.getPrice())
 			.build();
 
 	}

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/application/service/StockService.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/application/service/StockService.java
@@ -11,6 +11,7 @@ import com.teamsparta8.stock_service.domain.service.StockDomainService;
 import com.teamsparta8.stock_service.presentation.dto.CreateStockRequest;
 import com.teamsparta8.stock_service.presentation.dto.CreateStockResponse;
 import com.teamsparta8.stock_service.presentation.dto.DecreaseStockRequest;
+import com.teamsparta8.stock_service.presentation.dto.RollbackStockRequest;
 import com.teamsparta8.stock_service.presentation.dto.StockCheckResponse;
 import com.teamsparta8.stock_service.presentation.dto.UpdateStockResponse;
 
@@ -35,9 +36,10 @@ public class StockService {
 		// }
 		// UUID huubId = prodcut.getHubId();
 		UUID dummyHubId = UUID.randomUUID();
-
+		// int Price = 1000;
 		//  ProductService에서 받은 hubId 사용
-		Stock stock = stockDomainService.createStock(request.getProductId(), dummyHubId, request.getQuantity());
+		Stock stock = stockDomainService.createStock(request.getProductId(), dummyHubId, request.getQuantity(),
+			request.getPrice());
 
 		return stockMapper.fromEntity(stock);
 	}
@@ -62,6 +64,13 @@ public class StockService {
 			.hubId(stock.getHubId()) // StockDomainService에서 조회한 hubId
 			.price(price)
 			.build();
+	}
+
+	//복원 로직
+	@Transactional
+	public void rollbackStock(RollbackStockRequest request) {
+		Stock stock = stockDomainService.findStockByProduct(request.getProductId());
+		stockDomainService.increaseStock(stock, request.getQuantity());
 	}
 	//재고 조회
 	@Transactional(readOnly = true)

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/application/service/StockService.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/application/service/StockService.java
@@ -68,9 +68,13 @@ public class StockService {
 
 	//복원 로직
 	@Transactional
-	public void rollbackStock(RollbackStockRequest request) {
-		Stock stock = stockDomainService.findStockByProduct(request.getProductId());
-		stockDomainService.increaseStock(stock, request.getQuantity());
+	public void rollbackStock(UUID productId, int quantity) {
+		Stock stock = findStockByProduct(productId); // 이제 오류 안 뜸!
+		stock.increaseStock(quantity);
+	}
+	@Transactional(readOnly = true)
+	public Stock findStockByProduct(UUID productId) {
+		return stockDomainService.findStockByProduct(productId);
 	}
 	//재고 조회
 	@Transactional(readOnly = true)

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/application/service/StockService.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/application/service/StockService.java
@@ -69,7 +69,7 @@ public class StockService {
 	//복원 로직
 	@Transactional
 	public void rollbackStock(UUID productId, int quantity) {
-		Stock stock = findStockByProduct(productId); // 이제 오류 안 뜸!
+		Stock stock = findStockByProduct(productId);
 		stock.increaseStock(quantity);
 	}
 	@Transactional(readOnly = true)

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/domain/model/Stock.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/domain/model/Stock.java
@@ -33,7 +33,7 @@ public class Stock extends BaseEntity{
 
 	@Column(nullable = false)
 	private int quantity;
-	@Column(nullable = false) // ✅ 가격 필드 추가
+	@Column(nullable = false) // 가격 필드 추가
 	private int price;
 
 	public void decreaseStock(int amount) {
@@ -48,5 +48,8 @@ public class Stock extends BaseEntity{
 			throw new IllegalArgumentException("재고는 0 이상이어야 합니다.");
 		}
 		this.quantity = newQuantity;
+	}
+	public void increaseStock(int amount) {
+		this.quantity += amount;
 	}
 }

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/domain/repository/StockRepository.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/domain/repository/StockRepository.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import com.teamsparta8.stock_service.domain.model.Stock;
 
 public interface StockRepository {
-	Optional<Stock> findByProductId(UUID productId);
+	Optional<Stock> findFirstByProductId(UUID productId);
 	Optional<Stock> findByHubIdAndProductId(UUID hubId, UUID productId);
 	Stock save(Stock stock);
 	void deleteByStockId(UUID stockId);

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/domain/service/StockDomainService.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/domain/service/StockDomainService.java
@@ -15,11 +15,12 @@ import lombok.RequiredArgsConstructor;
 public class StockDomainService {
 	private final StockRepository stockRepository;
 	@Transactional
-	public Stock createStock(UUID productId, UUID hubId, int quantity) {
+	public Stock createStock(UUID productId, UUID hubId, int quantity,int price) {
 		Stock stock = Stock.builder()
 			.productId(productId)
 			.hubId(hubId)
 			.quantity(quantity)
+			.price(price)
 			.build();
 
 		return stockRepository.save(stock);
@@ -28,7 +29,7 @@ public class StockDomainService {
 
 	// `productId` 기반으로 Stock 조회
 	public Stock findStockByProduct(UUID productId) {
-		return stockRepository.findByProductId(productId)
+		return stockRepository.findFirstByProductId(productId)
 			.orElseThrow(() -> new RuntimeException("해당 상품의 재고가 없습니다."));
 	}
 
@@ -60,6 +61,19 @@ public class StockDomainService {
 		stockRepository.deleteByStockId(stockId);
 	}
 
+	@Transactional
+	public void increaseStock(Stock stock, int quantity) {
+		stock.increaseStock(quantity);
+		stockRepository.save(stock);
+	}
+
+	//유효성 체크
+	public void rollbackStock(Stock stock, int quantity) {
+		// 실제 재고가 적다면 더해주기 전에 검증
+		if (quantity < 0) throw new IllegalArgumentException("복구 수량은 0보다 커야 합니다.");
+		stock.increaseStock(quantity);
+		stockRepository.save(stock);
+	}
 
 
 }

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/infrastructure/repository/StockRepositoryImpl.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/infrastructure/repository/StockRepositoryImpl.java
@@ -16,7 +16,7 @@ public class StockRepositoryImpl implements StockRepository {
 	private final JpaStockRepository jpaStockRepository;
 
 	@Override
-	public Optional<Stock> findByProductId(UUID productId) {
+	public Optional<Stock> findFirstByProductId(UUID productId) {
 		return jpaStockRepository.findByProductId(productId);
 	}
 

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/presentation/controller/StockController.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/presentation/controller/StockController.java
@@ -19,6 +19,7 @@ import com.teamsparta8.stock_service.presentation.dto.CommonResponse;
 import com.teamsparta8.stock_service.presentation.dto.CreateStockRequest;
 import com.teamsparta8.stock_service.presentation.dto.CreateStockResponse;
 import com.teamsparta8.stock_service.presentation.dto.DecreaseStockRequest;
+import com.teamsparta8.stock_service.presentation.dto.RollbackStockRequest;
 import com.teamsparta8.stock_service.presentation.dto.StockCheckResponse;
 import com.teamsparta8.stock_service.presentation.dto.UpdateStockResponse;
 
@@ -70,6 +71,13 @@ public class StockController {
 	public ResponseEntity<CommonResponse<Void>> deleteStock(@PathVariable UUID stockId) {
 		stockService.deleteStock(stockId);
 		return ResponseEntity.ok(CommonResponse.OK("재고 삭제 성공"));
+	}
+
+	//주문 실패 시 재고 롤백
+	@PutMapping("/rollback")
+	public ResponseEntity<CommonResponse<String>> rollbackStock(@RequestBody RollbackStockRequest request) {
+		stockService.rollbackStock(request);
+		return ResponseEntity.ok(CommonResponse.OK(null, "재고 복구 성공"));
 	}
 
 }

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/presentation/controller/StockController.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/presentation/controller/StockController.java
@@ -56,6 +56,14 @@ public class StockController {
 	}
 
 
+	//주문 실패 시 재고 롤백
+	@PutMapping("/rollback")
+	public ResponseEntity<CommonResponse<String>> rollbackStock(
+		@RequestBody RollbackStockRequest request) {
+
+		stockService.rollbackStock(request.getProductId(), request.getQuantity());
+		return ResponseEntity.ok(CommonResponse.OK("재고 복구 완료", "success"));
+	}
 	// 재고 업데이트
 	@PutMapping("/{productId}")
 	public ResponseEntity<CommonResponse<UpdateStockResponse>> updateStock(
@@ -71,13 +79,6 @@ public class StockController {
 	public ResponseEntity<CommonResponse<Void>> deleteStock(@PathVariable UUID stockId) {
 		stockService.deleteStock(stockId);
 		return ResponseEntity.ok(CommonResponse.OK("재고 삭제 성공"));
-	}
-
-	//주문 실패 시 재고 롤백
-	@PutMapping("/rollback")
-	public ResponseEntity<CommonResponse<String>> rollbackStock(@RequestBody RollbackStockRequest request) {
-		stockService.rollbackStock(request);
-		return ResponseEntity.ok(CommonResponse.OK(null, "재고 복구 성공"));
 	}
 
 }

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/presentation/controller/StockController.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/presentation/controller/StockController.java
@@ -24,7 +24,9 @@ import com.teamsparta8.stock_service.presentation.dto.StockCheckResponse;
 import com.teamsparta8.stock_service.presentation.dto.UpdateStockResponse;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/stocks")
 @RequiredArgsConstructor
@@ -60,7 +62,6 @@ public class StockController {
 	@PutMapping("/rollback")
 	public ResponseEntity<CommonResponse<String>> rollbackStock(
 		@RequestBody RollbackStockRequest request) {
-
 		stockService.rollbackStock(request.getProductId(), request.getQuantity());
 		return ResponseEntity.ok(CommonResponse.OK("재고 복구 완료", "success"));
 	}

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/presentation/dto/CreateStockResponse.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/presentation/dto/CreateStockResponse.java
@@ -12,4 +12,5 @@ public class CreateStockResponse {
 	private UUID hubId;
 	private UUID productId;
 	private int quantity;
+	private int price;
 }

--- a/stock-service/src/main/java/com/teamsparta8/stock_service/presentation/dto/RollbackStockRequest.java
+++ b/stock-service/src/main/java/com/teamsparta8/stock_service/presentation/dto/RollbackStockRequest.java
@@ -2,15 +2,15 @@ package com.teamsparta8.stock_service.presentation.dto;
 
 import java.util.UUID;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class CreateStockRequest {
-	private UUID hubId;
+@AllArgsConstructor
+public class RollbackStockRequest {
 	private UUID productId;
 	private int quantity;
-	private int price;
 
 }

--- a/stock-service/src/main/resources/application.yml
+++ b/stock-service/src/main/resources/application.yml
@@ -1,0 +1,32 @@
+server:
+  port: 8082
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: 1234
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update
+    #    data:
+    #      redis:
+    #        host: localhost
+    #        port: 6379
+
+
+    properties:
+      show-sql: true
+      format_sql: true
+      highlight_sql: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug #logger
+    org.hibernate.orm.jdbc.bind: trace #?? ???? ?? ???
+eureka:
+  client:
+    registerWithEureka: false
+    fetchRegistry: false


### PR DESCRIPTION
### **📌 작업 내용**
-주문 생성에서의 보상 트랜잭션 구현했습니다.
-주문 수정,삭제에서도 재고 관련 트랜잭션 구현했습니다.
-Order->Delivery , Order->Stock, Stock->Product 연동 코드 구현하였습니다.
-API 테스트 전체 진행 완료했습니다.
 
 - As-is
     - (변경 전 설명을 여기에 작성)
 - To-be
     - (변경 후 설명을 여기에 작성)
 
 ### **🧑‍💻 작업 유형**
 
 - [x]  새로운 기능 추가
 - [ ]  버그 수정
 - [x]  코드 리팩토링
 - [ ]  문서 수정
 - [ ]  설정 변경
 - [ ]  CI/CD 변경
 
 ### **📷 관련 이미지**
 
 해당 Pull Request와 관련된 이미지가 있을 경우 여기에 첨부해주세요.
 
 ### **🚨 주의 사항**
-Order, Stock을 동시에 수정할 일이 많아서 불가피하게 같은 브랜치로 수정을 하였으나 Commit으로 구분지어 뒀습니다!

- 주문 생성시 보상 트랜잭션에 관련된 내용입니다. 
흐름을 설명하자면 
주문요청(Stock Service에 재고 차감 요청)
 -> 재고 충분하면 차감 후, 차감된 가격과 허브Id 반환
-> OrderService에서 주문 생성 후 DB저장(DeliveryId=nuill) 
-> DeliveryService에 배송 생성 요청 
-> Delivery 생성 실패 시, Stock 롤백(보상 트랜잭션)
-> Delivery 생성 성공 시 DeliveryId 반환하여 Update후 저장 
이런 식입니다.  보상 트랜잭션은 SAGA 패턴의 Orchestration 방식을 이용하여 구현하였습니다.

![image](https://github.com/user-attachments/assets/9c7bc390-ce16-4d8e-bcb1-a1c1eebd5409)


-주문 수정은 수정 quantity에 맞게 재고 차감, 증가가 가능합니다.
-주문 삭제 후에 재고 복원이 가능합니다.
 
 ### **🤔 토론**
 
-이제 막 든 생각인데 주문자를 알기 위해 userId가 필요한 것 같습니다......ㅜ